### PR TITLE
Update to Switzerland (CH) specific stores and links.

### DIFF
--- a/src/js/data.js
+++ b/src/js/data.js
@@ -910,16 +910,6 @@ export const sites = [
     url: 'https://www.techmania.ch/Search/DoSearch?suche=%s',
   },
   {
-    country: 'CH',
-    name: 'Ricardo',
-    url: 'https://www.ricardo.ch/de/s/%s',
-  },
-  {
-    country: 'CH',
-    name: 'Microspot',
-    url: 'https://www.microspot.ch/de/search?search=%s',
-  },
-  {
     country: 'UK',
     name: 'Amazon UK',
     url: 'https://www.amazon.co.uk/s?k=%s',

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -882,22 +882,22 @@ export const sites = [
   {
     country: 'CH',
     name: 'Digitec',
-    url: 'https://www.digitec.ch/de/Search?q=%s',
+    url: 'https://www.digitec.ch/producttype/ram-2?q=%s',
   },
   {
     country: 'CH',
     name: 'Brack',
-    url: 'https://www.brack.ch/search?query=%s',
+    url: 'https://www.brack.ch/it-multimedia/pc-komponenten/arbeitsspeicher/memory-ram?query=%s',
   },
   {
     country: 'CH',
-    name: 'Microspot',
-    url: 'https://www.microspot.ch/de/search?search=%s',
+    name: 'toppreise.ch',
+    url: 'https://www.toppreise.ch/index.php?search=%s',
   },
   {
     country: 'CH',
     name: 'Alternate.ch',
-    url: 'https://www.alternate.ch/html/search.html?query=%s',
+    url: 'https://www.alternate.ch/listing.xhtml?q=%s',
   },
   {
     country: 'CH',
@@ -916,8 +916,8 @@ export const sites = [
   },
   {
     country: 'CH',
-    name: 'toppreise.ch',
-    url: 'https://www.toppreise.ch/index.php?search=%s',
+    name: 'Microspot',
+    url: 'https://www.microspot.ch/de/search?search=%s',
   },
   {
     country: 'UK',


### PR DESCRIPTION
- Updated some broken Links (Alternate Switzerland) and updated others to be more specific (digitec searches in Ram category, Brack will now open Product Page if found instead of just the search results). Moved price comparison website further up because it lists pretty much all the stores anyway. The two most used stores in Switzerland are still at the top.
- Removed Ricardo (auction platform) because there were 0 hits (most sellers don't add the correct SKU). If buyers want to check for second-hand options they should just look up a stick they found at a local reseller like brack or digitec. It's quite unlikely they would find sticks sold in US/Non-EU anyway). Microspot was removed due to lack of hits too.. It's also listed in toppreise.ch, so it is still available... in the rare case, they actually do sell the ram stick(s).