### PR TITLE
Update data.js

### DIFF
--- a/src/js/data.js
+++ b/src/js/data.js
@@ -517,9 +517,7 @@ export const skus = [
   'F4-4300C19Q2-64GTRG',
   'F4-3200C14D-32GTZN',
   'F4-3200C14Q-64GTZN',
-  /* not guaranteed, see #21
   'F4-3600C16D-32GTZN',
-  */
   'F4-3600C16Q-64GTZN',
   'F4-3600C14D-16GTZNB',
   'F4-3600C14Q-32GTZNB',


### PR DESCRIPTION
Multiple sources have confirmed F4-3600C16D-32GTZN as using a Samsung B-Die kit. Issue #21 seems to relate to [GTZNC](https://www.gskill.com/product/165/326/1562840211/F4-3600C16D-32GTZNC-Overview) and not [GTZN](https://www.gskill.com/product/165/326/1562839473/F4-3600C16D-32GTZN-Overview).